### PR TITLE
No need of explicitly mentioned locally installed plugins in book.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "url": "https://github.com/GitbookIO/plugin-superscript/issues"
     },
     "devDependencies": {
-        "gitbook-tester": "1.0.2",
+        "gitbook-tester": "1.0.3",
         "mocha": "2.3.4"
     },
     "scripts": {

--- a/test/index.js
+++ b/test/index.js
@@ -6,9 +6,6 @@ describe('superscript', function() {
     it('should correctly replace by sup html tag', function() {
         return tester.builder()
             .withContent('#test me \n\nHello world. {% sup %}superscript text!{% endsup %}')
-            .withBookJson({
-                plugins: ['superscript']
-            })
             .withLocalPlugin(path.join(__dirname, '..'))
             .create()
             .then(function(result) {


### PR DESCRIPTION
Removed explicit `.withBookJson` call, based on https://github.com/todvora/gitbook-tester/issues/2#issuecomment-160671930.
